### PR TITLE
Stop sending welcome emails after athlete creation

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,14 +32,6 @@
     "SECRET_KEY_BASE": {
       "generator": "secret"
     },
-    "SMTP_PROVIDER_USERNAME": {
-      "required": false,
-      "value": ""
-    },
-    "SMTP_PROVIDER_PASSWORD": {
-      "required": false,
-      "value": ""
-    },
     "STRAVA_API_CLIENT_ID": {
       "required": false,
       "value": ""

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,5 @@
 class UserMailer < ApplicationMailer
+  # DEPRECATED. This is now handled by MailChimp workflow.
   def welcome_email(athlete)
     return if athlete.nil?
 

--- a/app/models/athlete.rb
+++ b/app/models/athlete.rb
@@ -12,7 +12,6 @@ class Athlete < ApplicationRecord
   has_many :heart_rate_zones
   has_many :races
 
-  after_create :send_welcome_email
   before_destroy :remove_from_mailing_list
 
   def self.find_by_access_token(access_token)
@@ -34,9 +33,5 @@ class Athlete < ApplicationRecord
 
   def remove_from_mailing_list
     RemoveFromMailingListJob.perform_later(id, email)
-  end
-
-  def send_welcome_email
-    UserMailer.delay(priority: 1).welcome_email(self)
   end
 end

--- a/lib/mailchimp_api_wrapper.rb
+++ b/lib/mailchimp_api_wrapper.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 class MailChimpApiWrapper
   def initialize
     @api_client = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
@@ -46,6 +48,7 @@ class MailChimpApiWrapper
       JOIN_DATE: athlete.created_at.strftime('%Y/%m/%d'),
       FNAME: athlete.firstname,
       LNAME: athlete.lastname,
+      LAST_LOGIN: Time.now.utc.to_date.strftime('%Y/%m/%d'),
       URL: "#{Settings.app.production_url}/athletes/#{athlete.id}",
       STRAVA_URL: "#{Settings.strava.athletes_base_url}/#{athlete.id}"
     }

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,5 +1,6 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
+  # DEPRECATED. This is now handled by MailChimp workflow.
   def welcome_email
     athlete = Athlete.find_by_id_or_username(9123806)
     UserMailer.welcome_email(athlete)


### PR DESCRIPTION
This is now handled by MailChimp workflow. After athlete creation, it will be synced to MailChimp and MailChimp will send welcome emails instead of, so that open/click rates can be tracked and more consistent with newsletters.