### PR TITLE
Sort activities by start_date then elapsed_time

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -227,7 +227,7 @@ module ApplicationHelper
       end
 
       # Sort by start_date (not id) with the latest first.
-      shaped_items.sort_by! { |shaped_item| shaped_item[:start_date] }.reverse!
+      shaped_items.sort_by! { |shaped_item| [shaped_item[:start_date], -shaped_item[:elapsed_time]] }.reverse!
       shaped_items
     end
 


### PR DESCRIPTION
So that if there are best efforts for same distance on the same day,
the later/quicker will be after the slower one (in this case, progression chart won't go down and straight up)